### PR TITLE
Add upload and download commands

### DIFF
--- a/mawabot/cogs/messages/__init__.py
+++ b/mawabot/cogs/messages/__init__.py
@@ -11,9 +11,11 @@
 #
 
 from .core import Messages
+from .files import Files
 from .history import History
 
 def setup(bot):
     ''' Setup function to add cog to bot '''
     bot.add_cog(Messages(bot))
+    bot.add_cog(Files(bot))
     bot.add_cog(History(bot))

--- a/mawabot/cogs/messages/files.py
+++ b/mawabot/cogs/messages/files.py
@@ -65,7 +65,6 @@ class Files:
             embed.description = f'```py\n{traceback.format_exc()}\n```'
             embed.timestamp = datetime.now()
             await self.bot._send(embed=embed)
-
         await fut
 
     @staticmethod
@@ -90,8 +89,6 @@ class Files:
     async def download(self, ctx, posts: int = 1):
         ''' Downloads the last X urls from the current channel '''
 
-        fut = ctx.message.delete()
-
         # For "embed.color"
         # pylint: disable=assigning-non-slot
 
@@ -108,8 +105,10 @@ class Files:
             embed.description = f'\U0001f4c1 Saved **{count} files** to `{path}`'
             embed.timestamp = datetime.now()
 
-        await self.bot._send(embed=embed)
-        await fut
+        await asyncio.gather(
+            ctx.message.delete(),
+            self.bot._send(embed=embed),
+        )
 
     async def _download(self, ctx, posts):
         urls = []

--- a/mawabot/cogs/messages/files.py
+++ b/mawabot/cogs/messages/files.py
@@ -65,7 +65,7 @@ class Files:
 
     @staticmethod
     def _get_path(dir_path, url, discrim):
-        match = URL_FILENAME_REGEX.match(urls[i])
+        match = URL_FILENAME_REGEX.match(url)
         if match is None:
             name = f'{discrim}'
         else:
@@ -73,10 +73,13 @@ class Files:
 
         return os.path.join(dir_path, name)
 
-    async def _save(self, url, fileobj):
+    async def _save(self, url, path):
         async with aiohttp.ClientSession() as cs:
             async with cs.get(url) as req:
-                fileobj.write(await req.read())
+                data = await req.read()
+
+        with open(path, 'wb') as fh:
+            fh.write(data)
 
     @commands.command()
     async def dl(self, ctx, posts: int = 1):
@@ -103,7 +106,10 @@ class Files:
     async def _dl(self, ctx, posts):
         urls = []
         futures = []
+
+        # Create exclusive dir
         dir_path = os.path.join(self.dir, f'mawabot-dl-{ctx.message.id}')
+        os.mkdir(dir_path)
 
         # Gather all items to download
         before = discord.utils.snowflake_time(ctx.message.id)
@@ -118,7 +124,7 @@ class Files:
                 path = self._get_path(dir_path, url, i)
                 i += 1
 
-                futures.append(self._save(url, ))
+                futures.append(self._save(url, path))
 
             # Attachments
             for attach in msg.attachments:

--- a/mawabot/cogs/messages/files.py
+++ b/mawabot/cogs/messages/files.py
@@ -15,7 +15,6 @@
 import asyncio
 import os
 import re
-import time
 import traceback
 from datetime import datetime
 
@@ -81,6 +80,9 @@ class Files:
         ''' Downloads the last X urls from the current channel '''
 
         fut = ctx.message.delete()
+
+        # For "embed.color"
+        # pylint: disable=assigning-non-slot
 
         try:
             count, path = await self._dl(ctx, posts)

--- a/mawabot/cogs/messages/files.py
+++ b/mawabot/cogs/messages/files.py
@@ -24,7 +24,7 @@ import discord
 from discord.ext import commands
 
 URL_REGEX = re.compile(r'https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b(?:[-a-zA-Z0-9@:%_\+.~#?&//=]*)')
-URL_FILENAME_REGEX = re.compile(r'^.*\/([^\/ ]+)$')
+URL_FILENAME_REGEX = re.compile(r'^https?:\/\/.*\/([^\/ ]+)$')
 
 class Files:
     __slots__ = (
@@ -88,7 +88,7 @@ class Files:
         fut = ctx.message.delete()
 
         try:
-            urls, path = await self._dl(ctx, posts)
+            count, path = await self._dl(ctx, posts)
         except:
             embed = discord.Embed(type='rich', title='Download failed!')
             embed.color = discord.Color.red()
@@ -97,7 +97,7 @@ class Files:
         else:
             embed = discord.Embed(type='rich', title=f'Download complete!')
             embed.color = discord.Color.green()
-            embed.description = f'Downloaded **{len(urls)} files** to `{path}`'
+            embed.description = f'\U0001f4c1 Saved **{count} files** to `{path}`'
             embed.timestamp = datetime.now()
 
         await self.bot._send(embed=embed)
@@ -136,8 +136,8 @@ class Files:
         # Save list of URLs
         path = os.path.join(dir_path, 'urls.txt')
         with open(path, 'w') as fh:
-            fh.writelines(urls)
+            fh.write('\n'.join(urls))
 
         # Queue the downloads
         await asyncio.gather(*futures)
-        return urls, dir_path
+        return i, dir_path

--- a/mawabot/cogs/messages/files.py
+++ b/mawabot/cogs/messages/files.py
@@ -36,7 +36,7 @@ class Files:
         self.dir = self.bot.config['download-dir']
         os.makedirs(self.dir, exist_ok=True)
 
-    @commands.command()
+    @commands.command(name='upload', aliases=['up'])
     async def upload(self, ctx, *paths: str):
         ''' Uploads the given files from your filesystem to this channel '''
 
@@ -75,8 +75,8 @@ class Files:
         with open(path, 'wb') as fh:
             fh.write(data)
 
-    @commands.command()
-    async def dl(self, ctx, posts: int = 1):
+    @commands.command(name='download', aliases=['dl'])
+    async def download(self, ctx, posts: int = 1):
         ''' Downloads the last X urls from the current channel '''
 
         fut = ctx.message.delete()
@@ -85,7 +85,7 @@ class Files:
         # pylint: disable=assigning-non-slot
 
         try:
-            count, path = await self._dl(ctx, posts)
+            count, path = await self._download(ctx, posts)
         except:
             embed = discord.Embed(type='rich', title='Download failed!')
             embed.color = discord.Color.red()
@@ -100,7 +100,7 @@ class Files:
         await self.bot._send(embed=embed)
         await fut
 
-    async def _dl(self, ctx, posts):
+    async def _download(self, ctx, posts):
         urls = []
         futures = []
 

--- a/mawabot/cogs/messages/files.py
+++ b/mawabot/cogs/messages/files.py
@@ -40,6 +40,9 @@ class Files:
     async def upload(self, ctx, *paths: str):
         ''' Uploads the given files from your filesystem to this channel '''
 
+        # For "embed.color"
+        # pylint: disable=assigning-non-slot
+
         if not paths:
             return
 

--- a/mawabot/cogs/messages/files.py
+++ b/mawabot/cogs/messages/files.py
@@ -44,7 +44,7 @@ class Files:
             return
 
         fut = ctx.message.delete()
-        files = [discord.File(path) for path in paths]
+        files = [discord.File(path) for path in map(os.path.expanduser, paths)]
         if len(files) == 1:
             kwargs = {
                 'file': files[0],
@@ -54,7 +54,15 @@ class Files:
                 'files': files,
             }
 
-        await ctx.send(**kwargs)
+        try:
+            await ctx.send(**kwargs)
+        except:
+            embed = discord.Embed(type='rich', title='Upload failed!')
+            embed.color = discord.Color.red()
+            embed.description = f'```py\n{traceback.format_exc()}\n```'
+            embed.timestamp = datetime.now()
+            await self.bot._send(embed=embed)
+
         await fut
 
     @staticmethod

--- a/mawabot/cogs/messages/files.py
+++ b/mawabot/cogs/messages/files.py
@@ -45,12 +45,7 @@ class Files:
             return
 
         fut = ctx.message.delete()
-        files = []
-        for path in files:
-            with open(path, 'rb') as fh:
-                data = fh.read()
-            files.append(io.BytesIO(data))
-
+        files = [discord.File(path) for path in paths]
         if len(files) == 1:
             kwargs = {
                 'file': files[0],

--- a/mawabot/cogs/messages/files.py
+++ b/mawabot/cogs/messages/files.py
@@ -1,0 +1,121 @@
+#
+# cogs/files.py
+#
+# mawabot - Maware's selfbot
+# Copyright (c) 2017 Ma-wa-re, Ammon Smith
+#
+# mawabot is available free of charge under the terms of the MIT
+# License. You are free to redistribute and/or modify it under those
+# terms. It is distributed in the hopes that it will be useful, but
+# WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+#
+
+''' Has commands related to file uploads and downloads '''
+
+import asyncio
+import io
+import tarfile
+import re
+from datetime import datetime
+
+import aiohttp
+import discord
+from discord.ext import commands
+
+URL_REGEX = re.compile(r'https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b(?:[-a-zA-Z0-9@:%_\+.~#?&//=]*)')
+URL_FILENAME_REGEX = re.compile(r'^.*\/([^\/ ]+)$')
+
+class Files:
+    __slots__ = (
+        'bot',
+    )
+
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.command()
+    async def upload(self, ctx, *paths: str):
+        ''' Uploads the given files from your filesystem to this channel '''
+
+        if not paths:
+            return
+
+        fut = ctx.message.delete()
+        files = []
+        for path in files:
+            with open(path, 'rb') as fh:
+                data = fh.read()
+            files.append(io.BytesIO(data))
+
+        if len(files) == 1:
+            kwargs = {
+                'file': files[0],
+            }
+        else:
+            kwargs = {
+                'files': files,
+            }
+
+        await ctx.send(**kwargs)
+        await fut
+
+    async def _dl(self, url, fileobj):
+        async with aiohttp.request('GET', url) as req:
+            fileobj.write(await req.read())
+
+    @commands.command()
+    async def dl(self, ctx, posts: int = 1):
+        ''' Downloads the last X urls from the current channel '''
+
+        urls = []
+        files = []
+        futures = []
+
+        # Gather all items to download
+        before = discord.utils.snowflake_time(ctx.message.id)
+        async for msg in ctx.channel.history(limit=posts + 1, before=before):
+            if msg == ctx.message:
+                continue
+
+            # Links
+            for url in URL_REGEX.findall(msg.content):
+                urls.append(url)
+                fileobj = io.BytesIO()
+                files.append(fileobj)
+                futures.append(self._dl(url, fileobj))
+
+            # Attachments
+            for attach in msg.attachments:
+                urls.append(attach.url)
+                fileobj = io.BytesIO()
+                files.append(fileobj)
+                futures.append(attach.save(fileobj))
+
+        # Queue the downloads
+        await asyncio.gather(*futures)
+
+        # Add files to tar archive
+        tar_path = f'mawabot-dl-{ctx.message.id}.tar.gz'
+        with open(tar_path, 'wb') as fh:
+            with tarfile.open(fileobj=fh, mode='x:gz') as tar:
+                # Add list of urls found
+                fileobj = io.BytesIO('\n'.join(urls).encode('utf-8'))
+                tarinfo = tar.gettarinfo(name='urls.txt', fileobj=fileobj)
+                tar.addfile(tarinfo, fileobj)
+
+                # Add downloaded files
+                for i, fileobj in enumerate(files):
+                    match = URL_FILENAME_REGEX.match(urls[i])
+                    if match is None:
+                        name = f'{i}'
+                    else:
+                        name = f'{i}-{match[1]}'
+
+                    tarinfo = tar.gettarinfo(name=name, fileobj=fileobj)
+                    tar.addfile(tarinfo, fileobj)
+
+        # Announce that it's done
+        embed = discord.Embed(type='rich', title=f'Download for {ctx.message.id} complete!')
+        embed.timestamp = datetime.now()
+        embed.set_footer(name=f'{len(urls)} files downloaded')
+        await self.bot._send(embed=embed)

--- a/misc/config.yaml
+++ b/misc/config.yaml
@@ -11,5 +11,8 @@ token: 'your-bot-token-here'
 # Be warned this channel can and will get spammed!
 output-channel: ~
 
+# The directory to download all files to
+download-dir: /tmp/mawabot
+
 # The prefix used by the selfbot
 prefix: .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 PyYAML>=3.0
+aiohttp>=2.2
 astral>=1.2
 ckuehl-upsidedown>=0.4
 psutil>=5.2


### PR DESCRIPTION
Fixes #47 
Fixes #48 

Adds `.upload` and `.dl` to manage attachments: one uploads them from your filesystem, and the other downloads them and embedded URLs into a user-specified directory.